### PR TITLE
fix: use showdown and clicks work

### DIFF
--- a/example/vue2/package-lock.json
+++ b/example/vue2/package-lock.json
@@ -47,8 +47,8 @@
         "@capacitor/preferences": "^5.0.6",
         "@mytiki/capture-receipt-capacitor": "^0.7.0",
         "@mytiki/tiki-sdk-capacitor": "^0.3.2",
-        "vue": "2.7.14",
-        "vue-markdown-render": "^1.1.3"
+        "showdown": "^2.1.0",
+        "vue": "2.7.14"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",
@@ -57,6 +57,7 @@
         "@tsconfig/node18": "^18.2.0",
         "@types/markdown-it": "^13.0.0",
         "@types/node": "^20.5.0",
+        "@types/showdown": "^2.0.2",
         "@vitejs/plugin-vue2": "^2.2.0",
         "@vue/eslint-config-prettier": "^8.0.0",
         "@vue/eslint-config-typescript": "^12.0.0",
@@ -71,9 +72,9 @@
         "ts-node": "^10.9.1",
         "typedoc": "^0.25.0",
         "typescript": "^5.1.6",
+        "unplugin-vue-markdown": "^0.24.3",
         "vite": "^4.4.9",
         "vite-plugin-dts": "^3.5.2",
-        "vite-plugin-vue-markdown": "^0.23.8",
         "vite-plugin-vue2-svg": "^0.4.0",
         "vite-svg-loader": "^4.0.0",
         "vue-tsc": "^1.8.8"

--- a/src/components/sheet/sheet-bottom.vue
+++ b/src/components/sheet/sheet-bottom.vue
@@ -24,7 +24,7 @@ watch(
 <template>
   <div class="overlay" @click.stop.prevent="isShow = false">
     <Transition appear name="slide" @leave="$emit('dismiss')">
-      <div v-if="isShow" class="bottom-sheet" @click.stop.prevent>
+      <div v-if="isShow" class="bottom-sheet" @click.stop>
         <slot />
       </div>
     </Transition>

--- a/src/components/sheet/sheet-learn.vue
+++ b/src/components/sheet/sheet-learn.vue
@@ -4,24 +4,18 @@
   -->
 
 <script setup lang="ts">
-import VueMarkdown, { type Options } from "vue-markdown-render";
 import HeaderBack from "@/components/header/header-back.vue";
+import Showdown from "showdown";
 
 defineEmits(["back", "close"]);
-defineProps({
+const props = defineProps({
   markdown: {
     type: String,
     required: true,
   },
 });
 
-const options: Options = {
-  html: true,
-  xhtmlOut: true,
-  breaks: true,
-  linkify: false,
-  typographer: true,
-};
+const learn = new Showdown.Converter().makeHtml(props.markdown);
 </script>
 
 <template>
@@ -31,7 +25,7 @@ const options: Options = {
       @back="$emit('back')"
       @close="$emit('close')"
     />
-    <vue-markdown :source="markdown" :options="options" class="learn-more" />
+    <div class="learn-more" v-html="learn" />
   </div>
 </template>
 

--- a/src/components/sheet/sheet-terms.vue
+++ b/src/components/sheet/sheet-terms.vue
@@ -4,21 +4,22 @@
   -->
 
 <script setup lang="ts">
-import VueMarkdown from "vue-markdown-render";
 import ButtonText from "@/components/button/button-text.vue";
 import HeaderBack from "@/components/header/header-back.vue";
 import { inject } from "vue";
 import type { TikiService } from "@/service";
+import Showdown from "showdown";
 
 const tiki: TikiService = inject("Tiki")!;
 const emit = defineEmits(["back", "accept", "close"]);
-defineProps({
+const props = defineProps({
   markdown: {
     type: String,
     required: true,
   },
 });
 
+const terms = new Showdown.Converter().makeHtml(props.markdown);
 const accept = () => {
   tiki.publish.createLicense();
   emit("accept");
@@ -32,7 +33,7 @@ const accept = () => {
       @back="$emit('back')"
       @close="$emit('close')"
     />
-    <vue-markdown :source="markdown" class="terms" />
+    <div class="terms" v-html="terms" />
     <button-text text="I agree" class="agree" @click="accept" />
   </div>
 </template>

--- a/vue2/package.json
+++ b/vue2/package.json
@@ -39,7 +39,7 @@
     "@mytiki/capture-receipt-capacitor": "^0.7.0",
     "@mytiki/tiki-sdk-capacitor": "^0.3.2",
     "vue": "2.7.14",
-    "vue-markdown-render": "^1.1.3"
+    "showdown": "^2.1.0"
   },
   "devDependencies": {
     "@babel/types": "^7.22.5",
@@ -48,6 +48,7 @@
     "@tsconfig/node18": "^18.2.0",
     "@types/markdown-it": "^13.0.0",
     "@types/node": "^20.5.0",
+    "@types/showdown": "^2.0.2",
     "@vitejs/plugin-vue2": "^2.2.0",
     "@vue/eslint-config-prettier": "^8.0.0",
     "@vue/eslint-config-typescript": "^12.0.0",
@@ -60,14 +61,14 @@
     "typescript": "^5.1.6",
     "vite": "^4.4.9",
     "vite-plugin-dts": "^3.5.2",
-    "vite-plugin-vue-markdown": "^0.23.8",
     "vite-plugin-vue2-svg": "^0.4.0",
     "vue-tsc": "^1.8.8",
     "vite-svg-loader": "^4.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "unplugin-vue-markdown": "^0.24.3"
   },
   "peerDependencies": {
     "@capacitor/android": "^5.4.1",

--- a/vue2/vite.config.ts
+++ b/vue2/vite.config.ts
@@ -6,7 +6,7 @@
 import { defineConfig } from "vite";
 import * as path from "path";
 import vue from "@vitejs/plugin-vue2";
-import Markdown from "vite-plugin-vue-markdown";
+import Markdown from "unplugin-vue-markdown/vite";
 import { createSvgPlugin } from "vite-plugin-vue2-svg";
 
 module.exports = defineConfig({
@@ -14,7 +14,7 @@ module.exports = defineConfig({
     vue({
       include: [/\.vue$/, /\.md$/],
     }),
-    Markdown(),
+    Markdown({}),
     createSvgPlugin(),
   ],
   build: {

--- a/vue3/package.json
+++ b/vue3/package.json
@@ -39,7 +39,7 @@
     "@mytiki/capture-receipt-capacitor": "^0.7.0",
     "@mytiki/tiki-sdk-capacitor": "^0.3.2",
     "vue": "^3.3.4",
-    "vue-markdown-render": "^2.0.1"
+    "showdown": "^2.1.0"
   },
   "devDependencies": {
     "@babel/types": "^7.22.5",
@@ -49,6 +49,7 @@
     "@types/jest": "^29.5.5",
     "@types/markdown-it": "^13.0.0",
     "@types/node": "^20.5.0",
+    "@types/showdown": "^2.0.2",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vue/eslint-config-prettier": "^8.0.0",
     "@vue/eslint-config-typescript": "^12.0.0",
@@ -65,9 +66,9 @@
     "typescript": "^5.1.6",
     "vite": "^4.4.9",
     "vite-plugin-dts": "^3.5.2",
-    "vite-plugin-vue-markdown": "^0.23.8",
     "vite-svg-loader": "^4.0.0",
-    "vue-tsc": "^1.8.8"
+    "vue-tsc": "^1.8.8",
+    "unplugin-vue-markdown": "^0.24.3"
   },
   "peerDependencies": {
     "@capacitor/android": "^5.4.1",

--- a/vue3/vite.config.ts
+++ b/vue3/vite.config.ts
@@ -6,7 +6,7 @@
 import { defineConfig } from "vite";
 import * as path from "path";
 import vue from "@vitejs/plugin-vue";
-import Markdown from "vite-plugin-vue-markdown";
+import Markdown from "unplugin-vue-markdown/vite";
 import svgLoader from "vite-svg-loader";
 
 module.exports = defineConfig({
@@ -14,7 +14,7 @@ module.exports = defineConfig({
     vue({
       include: [/\.vue$/, /\.md$/],
     }),
-    Markdown(),
+    Markdown({}),
     svgLoader(),
   ],
   build: {


### PR DESCRIPTION
# Issues Addressed
resolves #270 
resolves #271 

## Additional Information
Moves markdown rendering to [showdown](https://github.com/showdownjs/showdown) which enables both more flexibility and improved support for Vue2/3
